### PR TITLE
Add Github workflow to generate arm64 and amd64 based docker images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,64 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
I've created a new GitHub Actions workflow file called docker-build.yml that will handle multi-architecture Docker image builds. Here's what this workflow does:

Triggers on:

Push to main branch
Any tag push matching v*.. pattern
Pull requests to main branch
Sets up the required tools:

QEMU for multi-architecture support
Docker Buildx for multi-platform builds
GitHub Container Registry authentication
Uses Docker metadata action to generate appropriate tags for the images

Builds and pushes Docker images for both AMD64 and ARM64 architectures using the following features:

Multi-platform build: linux/amd64,linux/arm64
GitHub Actions cache for faster builds
Automatic tag generation based on git refs
Only pushes on actual merges/tags, not on PRs
The workflow uses your existing Dockerfile, which should work fine for both architectures since it's based on node:23-alpine, which supports both AMD64 and ARM64.

To use this workflow:

Ensure you have the appropriate permissions set up for GitHub Container Registry (GHCR)
The workflow will automatically use your GitHub token for authentication
Images will be pushed to ghcr.io/<your-username>/poker-pocket-ts-backend
